### PR TITLE
feat!: remove renovate-config from package.json

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,3 +21,5 @@ jobs:
           node-version: 12.x
       - run: yarn install --frozen-lockfile
       - run: yarn test
+        env:
+          RENOVATE_CONFIG_FILE: default.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,16 +15,3 @@ jobs:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           package-name: renovate-config
           release-type: node
-      - uses: actions/checkout@v2
-        if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
-        if: ${{ steps.release.outputs.release_created }}
-      - run: yarn install --frozen-lockfile
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-        if: ${{ steps.release.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Add this into `.github/renovate.json`:
 
 ```json
 {
-  "extends": ["@inabagumi"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>inabagumi/renovate-config"]
 }
 ```
 

--- a/default.json
+++ b/default.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":automergeMinor",
+    ":automergeRequireAllStatusChecks",
+    ":dependencyDashboard",
+    ":disableRateLimiting",
+    ":enableRenovate",
+    ":enableVulnerabilityAlertsWithLabel(security)",
+    ":ignoreModulesAndTests",
+    ":label(dependencies)",
+    ":maintainLockFilesWeekly",
+    ":renovatePrefix",
+    ":semanticCommitTypeAll(build)",
+    ":widenPeerDependencies",
+    "group:monorepos",
+    "group:recommended",
+    "workarounds:all"
+  ],
+  "kubernetes": {
+    "fileMatch": ["^k8s/.+\\.yaml$"]
+  },
+  "packageRules": [
+    {
+      "description": "Group packages from nextra",
+      "groupName": "nextra monorepo",
+      "matchPackagePatterns": [
+        "nextra-theme-blog",
+        "nextra-theme-docs",
+        "nextra"
+      ]
+    },
+    {
+      "automerge": false,
+      "followTag": "latest",
+      "ignoreUnstable": false,
+      "matchPackagePatterns": ["^@docusaurus/"]
+    }
+  ],
+  "postUpdateOptions": ["gomodTidy", "yarnDedupeHighest"],
+  "rangeStrategy": "bump"
+}
+diff --git a/package.json b/package.json

--- a/default.json
+++ b/default.json
@@ -40,4 +40,3 @@
   "postUpdateOptions": ["gomodTidy", "yarnDedupeHighest"],
   "rangeStrategy": "bump"
 }
-diff --git a/package.json b/package.json

--- a/package.json
+++ b/package.json
@@ -10,84 +10,10 @@
   "homepage": "https://github.com/inabagumi/renovate-config",
   "license": "MIT",
   "name": "@inabagumi/renovate-config",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/inabagumi/renovate-config.git"
-  },
-  "renovate-config": {
-    "default": {
-      "extends": [
-        "config:base",
-        ":semanticCommitTypeAll(build)"
-      ],
-      "kubernetes": {
-        "fileMatch": [
-          "^k8s/.+\\.yaml$"
-        ]
-      },
-      "labels": [
-        "dependencies"
-      ],
-      "lockFileMaintenance": {
-        "enabled": true
-      },
-      "packageRules": [
-        {
-          "depTypeList": [
-            "engines",
-            "peerDependencies"
-          ],
-          "rangeStrategy": "auto"
-        },
-        {
-          "automerge": true,
-          "depTypeList": [
-            "dependencies"
-          ],
-          "updateTypes": [
-            "patch"
-          ]
-        },
-        {
-          "automerge": true,
-          "depTypeList": [
-            "devDependencies"
-          ],
-          "updateTypes": [
-            "digest",
-            "minor"
-          ]
-        },
-        {
-          "description": "Group packages from nextra",
-          "groupName": "nextra monorepo",
-          "matchPackagePatterns": [
-            "nextra-theme-blog",
-            "nextra-theme-docs",
-            "nextra"
-          ]
-        },
-        {
-          "automerge": true,
-          "packageNames": [
-            "renovate"
-          ]
-        },
-        {
-          "automerge": false,
-          "followTag": "latest",
-          "ignoreUnstable": false,
-          "matchPackagePatterns": [
-            "^@docusaurus/"
-          ]
-        }
-      ],
-      "postUpdateOptions": [
-        "gomodTidy",
-        "yarnDedupeHighest"
-      ],
-      "rangeStrategy": "bump"
-    }
   },
   "scripts": {
     "test": "renovate-config-validator"


### PR DESCRIPTION
BREAKING CHANGE: stop using npm-hosted presets, which are deprecated.